### PR TITLE
Add installation guide page and footer links

### DIFF
--- a/install.html
+++ b/install.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>プラグイン導入ガイド | Puchi Add-on Plugins</title>
+  <meta name="description" content="kintone ミニプラグインのインストールからアップデートまでの共通手順をまとめたガイドです。">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="kb-root">
+  <div class="kb-container kb-topbar">
+    <a class="kb-back" href="index.html">← 商品一覧に戻る</a>
+    <div class="kb-brand">Puchi Add-on Plugins</div>
+  </div>
+
+  <main class="kb-container">
+    <article class="kb-article">
+      <header class="kb-article-header">
+        <p class="kb-article-label">kintone ミニプラグイン導入ガイド</p>
+        <h1>インストール〜アップデートまでの共通手順</h1>
+        <div class="kb-article-meta">
+          <p><strong>最終更新：</strong>2025年9月</p>
+          <p><strong>対象：</strong>kintone システム管理者・アプリ管理者</p>
+          <p><strong>サポート窓口：</strong>ご購入時にご案内したメールアドレスまで</p>
+        </div>
+      </header>
+
+      <section class="kb-article-section">
+        <h2>配布ファイル構成</h2>
+        <ul class="kb-article-list">
+          <li><strong>プラグイン本体（ZIP）</strong>：kintone へそのままアップロードしてください。</li>
+          <li><strong>導入ガイド（PDF）</strong>：本ドキュメント。社内共有にもご利用ください。</li>
+        </ul>
+      </section>
+
+      <section class="kb-article-section">
+        <h2>想定読者</h2>
+        <p class="kb-article-paragraph">kintone の管理機能にアクセスできる担当者。IT 操作に不慣れな方でも手順を追えるよう記載しています。</p>
+      </section>
+
+      <section class="kb-article-section">
+        <h2>お問い合わせ前に</h2>
+        <p class="kb-article-paragraph">プラグイン名・バージョン、発生現象が分かるスクリーンショットをご用意いただくと解決がスムーズです。</p>
+      </section>
+
+      <nav class="kb-article-toc" aria-label="目次">
+        <h2>Contents</h2>
+        <ol class="kb-article-ordered">
+          <li><a href="#checklist">導入前のチェックリスト</a></li>
+          <li><a href="#package">プラグイン配布物の確認</a></li>
+          <li><a href="#install">kintone へのプラグイン追加手順</a></li>
+          <li><a href="#app-enable">アプリでの設定と有効化</a></li>
+          <li><a href="#update">プラグインのアップデート方法</a></li>
+          <li><a href="#troubleshoot">トラブルシュート</a></li>
+          <li><a href="#support">サポート窓口と連絡先</a></li>
+        </ol>
+      </nav>
+
+      <section id="checklist" class="kb-article-section">
+        <h2>1. 導入前のチェックリスト</h2>
+        <ul class="kb-article-check">
+          <li>kintone の「システム管理」メニューにアクセスできる権限をお持ちですか？</li>
+          <li>利用する環境（本番 or テスト）でプラグインの動作検証を行うスペース／アプリを用意しましたか？</li>
+          <li>ご利用のブラウザーは最新版ですか？（Google Chrome を推奨）</li>
+          <li>既存のプラグインと併用する場合、念のためテストアプリで競合が無いか確認することをおすすめします。</li>
+        </ul>
+        <p class="kb-article-callout"><strong>ご注意：</strong>プラグインの追加や更新は、アプリに影響が出る可能性があります。本番アプリに適用する前にテストアプリで検証してください。</p>
+      </section>
+
+      <section id="package" class="kb-article-section">
+        <h2>2. プラグイン配布物の確認</h2>
+        <p class="kb-article-paragraph">ダウンロードした ZIP の中身を確認し、少なくとも以下のファイルが揃っていることを確かめてください。</p>
+        <ul class="kb-article-list">
+          <li><strong>プラグイン本体（ZIP）</strong>：kintone にアップロードするファイルです。解凍せず、そのまま使用します。</li>
+          <li><strong>導入ガイド PDF</strong>：操作手順書。本ドキュメントが該当します。</li>
+        </ul>
+        <p class="kb-article-hint">ヒント：Windows で ZIP を右クリックし「すべて展開」を選ぶとフォルダーが開きます。Mac の場合はダブルクリックで展開されます。</p>
+      </section>
+
+      <section id="install" class="kb-article-section">
+        <h2>3. kintone へのプラグイン追加手順</h2>
+        <ol class="kb-article-steps">
+          <li>
+            <h3>kintone のシステム管理を開きます</h3>
+            <p>画面右上のアカウントメニューから 「システム管理」（または「管理者設定」）を選択します。</p>
+            <p class="kb-screenshot-callout">★ スクリーンショット「システム管理メニュー」の挿入位置</p>
+          </li>
+          <li>
+            <h3>プラグイン管理画面へ移動</h3>
+            <p>左側のメニューから 「カスタマイズ／サービス連携」&gt;「プラグイン」 を開き、右上の 「プラグインの追加」&gt;「ファイルから」 をクリックします。</p>
+          </li>
+          <li>
+            <h3>プラグインファイルを選択</h3>
+            <p>配布されたプラグイン本体（ZIP）を選択し、「追加」をクリックします。アップロード完了後、一覧に表示されます。</p>
+            <p class="kb-screenshot-callout">★ スクリーンショット「プラグイン一覧に表示」の挿入位置</p>
+          </li>
+          <li>
+            <h3>有効化の準備</h3>
+            <p>追加できたら、該当プラグインのステータスが「利用可能」になっていることを確認してください。アプリへの適用は次の章で行います。</p>
+          </li>
+        </ol>
+      </section>
+
+      <section id="app-enable" class="kb-article-section">
+        <h2>4. アプリでの設定と有効化</h2>
+        <ol class="kb-article-steps">
+          <li>
+            <h3>プラグインを使うアプリを開く</h3>
+            <p>アプリの設定（歯車アイコン）&gt; 「プラグイン」 を選択し、「+ プラグインを追加」 をクリックします。</p>
+          </li>
+          <li>
+            <h3>プラグインの設定画面に入る</h3>
+            <p>一覧から対象プラグインを選択し、「設定」ボタンをクリック。画面の案内に沿って必要項目を入力し、保存します。</p>
+            <p class="kb-screenshot-callout">★ スクリーンショット「設定画面」の挿入位置</p>
+          </li>
+          <li>
+            <h3>アプリを更新（再利用）</h3>
+            <p>設定を保存したら、アプリ設定画面右上の 「保存」、続いて黄色の 「アプリを更新」 ボタンを押してください。これでプラグインが有効になります。</p>
+          </li>
+          <li>
+            <h3>動作確認</h3>
+            <p>アプリ画面に戻り、想定どおりに動作するか確認します。問題がある場合は設定値や他プラグインとの競合をチェックしてください。</p>
+          </li>
+        </ol>
+      </section>
+
+      <section id="update" class="kb-article-section">
+        <h2>5. プラグインのアップデート方法</h2>
+        <ol class="kb-article-steps">
+          <li>配布サイトから最新版のプラグイン本体（ZIP）とガイドをダウンロードします。</li>
+          <li>kintone システム管理 &gt; プラグイン一覧で対象プラグインの 「…（メニュー）」&gt;「更新」 を選択します。</li>
+          <li>新しい ZIP を指定し、アップロード後にアプリ設定画面で 「アプリを更新」 を忘れずに実行します。</li>
+          <li>必要に応じて、リリースノートや変更点をアプリ利用者へ共有してください。</li>
+          <li>旧バージョンの ZIP はバックアップとして保管しておくと、万一のロールバック時に安心です。</li>
+        </ol>
+      </section>
+
+      <section id="troubleshoot" class="kb-article-section">
+        <h2>6. トラブルシュート</h2>
+        <h3 class="kb-article-subheading">画面が真っ白になる／プラグインが動かない場合</h3>
+        <ul class="kb-article-check">
+          <li>ブラウザーの再読み込み（Ctrl + F5 または Cmd + Shift + R）を実行してください。</li>
+          <li>他プラグインを一時的に無効化し、競合が無いか切り分けます。</li>
+          <li>プラグイン設定内容が正しいか、入力漏れが無いか確認します。</li>
+        </ul>
+        <h3 class="kb-article-subheading">アップデート後にエラーが出る場合</h3>
+        <ul class="kb-article-check">
+          <li>アプリを更新し忘れていないか確認してください。</li>
+          <li>アプリのカスタマイズ JavaScript / CSS との競合も考えられるため、一時的に無効化して様子を見ます。</li>
+          <li>エラーメッセージが表示される場合は、スクリーンショットを撮影してサポート窓口へお知らせください。</li>
+        </ul>
+      </section>
+
+      <section id="support" class="kb-article-section">
+        <h2>7. サポート窓口と連絡先</h2>
+        <p class="kb-article-paragraph">解決しない場合は、以下の情報を添えてサポート窓口までご連絡ください。</p>
+        <ul class="kb-article-list">
+          <li>ご利用中のプラグイン名とバージョン</li>
+          <li>発生日時・操作手順</li>
+          <li>表示されたエラーメッセージやスクリーンショット</li>
+          <li>kintone のドメイン名（例：example.cybozu.com）</li>
+        </ul>
+        <p class="kb-article-paragraph">サポート窓口：ご購入時にご案内したメールアドレス / フォーム</p>
+        <p class="kb-article-paragraph">受付時間：平日 10:00 – 18:00（日本時間）※祝日・弊社指定休日を除く</p>
+      </section>
+
+      <p class="kb-article-footer">© 2025 Mini Plugin Team. All rights reserved. 無断転載を禁じます。</p>
+    </article>
+  </main>
+
+  <footer class="kb-footer kb-container">
+    <nav class="kb-footer-links">
+      <a href="mailto:c.otkyaaa@gmail.com">不具合報告</a>
+      <a href="install.html">プラグイン導入ガイド</a>
+      <a href="terms.html">利用規約</a>
+    </nav>
+    <small>© 2025 Mini Plugin Team. All rights reserved.</small>
+  </footer>
+</body>
+</html>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -184,7 +184,7 @@ try{
   // assets は丸ごと
   copy('assets');
   // 単体ファイル
-  ['style.css','terms.html','robots.txt','sitemap-base.xml','404.html'].forEach(copy);
+  ['style.css','terms.html','install.html','robots.txt','sitemap-base.xml','404.html'].forEach(copy);
 
   // sitemap
   const basePath=path.join(DIST,'sitemap-base.xml');
@@ -192,6 +192,7 @@ try{
   const urls=['/index.html'];
   if(ENABLE_EN) urls.push('/en/index.html');
   urls.push('/terms.html');
+  urls.push('/install.html');
   for(const p of products){
     urls.push(`/products/${p.slug}.html`);
     if(ENABLE_EN) urls.push(`/products/en/${p.slug}.html`);

--- a/style.css
+++ b/style.css
@@ -32,6 +32,35 @@
 .kb-root a{color:var(--kb-primary);text-decoration:none}
 .kb-root a:hover{text-decoration:underline}
 .kb-root a:focus-visible{outline:2px solid var(--kb-primary-600);outline-offset:2px}
+.kb-article{background:#fff;border:1px solid var(--kb-line);border-radius:20px;padding:48px 56px;box-shadow:0 16px 38px rgba(15,23,42,.08);max-width:880px;margin:0 auto 80px}
+.kb-article-header h1{font-size:30px;font-weight:800;line-height:1.35;margin:6px 0 0}
+.kb-article-label{display:inline-block;font-size:13px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--kb-primary);background:#ecf2ff;border-radius:999px;padding:6px 14px}
+.kb-article-meta{margin-top:18px;display:grid;gap:6px;color:var(--kb-sub);font-size:14px}
+.kb-article-section{margin-top:40px}
+.kb-article-section:first-of-type{margin-top:32px}
+.kb-article-section h2{font-size:22px;font-weight:800;margin:0;color:var(--kb-text)}
+.kb-article-paragraph{margin-top:12px;color:var(--kb-sub);line-height:1.8}
+.kb-article-list,.kb-article-check{list-style:disc;padding-left:1.6em;margin:14px 0 0;display:grid;gap:8px;color:var(--kb-text)}
+.kb-article-check{list-style:disc}
+.kb-article-ordered{list-style:decimal;padding-left:1.6em;margin:12px 0 0;display:grid;gap:6px;font-weight:600}
+.kb-article-ordered a{color:var(--kb-primary)}
+.kb-article-toc{margin-top:40px;background:#f1f5ff;border:1px solid #d8e3ff;border-radius:16px;padding:24px 28px}
+.kb-article-toc h2{margin:0 0 12px;font-size:18px;font-weight:700;color:#26457b}
+.kb-article-steps{list-style:decimal;padding-left:1.6em;margin:18px 0 0;display:grid;gap:22px;color:var(--kb-text)}
+.kb-article-steps li{padding-left:4px}
+.kb-article-steps h3{font-size:17px;font-weight:700;margin:0 0 8px;color:var(--kb-text)}
+.kb-article-steps p{margin:0 0 6px;color:var(--kb-sub);line-height:1.7}
+.kb-article-callout{margin-top:16px;padding:14px 18px;border-radius:12px;background:#fff7eb;border-left:4px solid #f59e0b;font-size:14px;color:#8a5300}
+.kb-article-hint{margin-top:16px;padding:12px 16px;border-radius:12px;background:#eef5ff;border-left:4px solid #3b82f6;color:#2c4a7a;font-size:14px}
+.kb-screenshot-callout{margin-top:12px;padding:10px 14px;border-radius:12px;border:1px dashed var(--kb-line);background:#f9fbff;font-size:13px;color:var(--kb-sub)}
+.kb-article-subheading{margin:28px 0 10px;font-size:18px;font-weight:700;color:var(--kb-text)}
+.kb-article-footer{margin-top:48px;font-size:12.5px;color:var(--kb-sub);text-align:center}
+@media (max-width:720px){
+  .kb-article{padding:32px 24px;margin-bottom:48px}
+  .kb-article-header h1{font-size:26px}
+  .kb-article-section h2{font-size:20px}
+  .kb-article-toc{padding:20px}
+}
 
 /* ===== LAYOUT ===== */
 .kb-container{max-width:1080px;margin:0 auto;padding:24px}

--- a/templates/index-ja.html
+++ b/templates/index-ja.html
@@ -44,6 +44,7 @@
   <footer class="kb-footer kb-container">
     <nav class="kb-footer-links">
       <a href="mailto:%%SUPPORT_MAIL%%">不具合報告</a>
+      <a href="install.html">プラグイン導入ガイド</a>
       <a href="terms.html">利用規約</a>
     </nav>
     <small>%%SITE_COPYRIGHT%%</small>

--- a/templates/product-ja.html
+++ b/templates/product-ja.html
@@ -79,6 +79,7 @@
   <footer class="kb-footer kb-container">
     <nav class="kb-footer-links">
       <a href="mailto:%%SUPPORT_MAIL%%">不具合報告</a>
+      <a href="../install.html">プラグイン導入ガイド</a>
       <a href="../terms.html">利用規約</a>
     </nav>
     <small>%%SITE_COPYRIGHT%%</small>


### PR DESCRIPTION
## Summary
- add a dedicated installation guide page for kintone mini plugins and wire it into the site footer
- introduce article-specific styling to render the new guide cleanly
- ensure the build copies the guide and lists it in the generated sitemap

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9df1fc4b48324895301118d7abbf0