### PR TITLE
Update stp-viewer links to stp-viewer.plugbits.app

### DIFF
--- a/docs/factory-tools/index.html
+++ b/docs/factory-tools/index.html
@@ -698,7 +698,7 @@
             <div class="hero-badge" style="background:#cffafe; color:#0891b2;" data-i18n="badgeStp"></div>
             <h1 data-i18n="titleStp"></h1>
             <p data-i18n="descStp"></p>
-            <a href="https://plugbits.github.io/stp-viewer/" class="launch-btn launch-cyan tool-link" data-tool="stp" target="_blank" rel="noopener">
+            <a href="https://stp-viewer.plugbits.app/" class="launch-btn launch-cyan tool-link" data-tool="stp" target="_blank" rel="noopener">
               <span data-i18n="openTool"></span> <span>→</span>
             </a>
           </div>
@@ -1006,7 +1006,7 @@
       calc:       'https://plugbits.github.io/ForgeKit/',
       st:         'https://plugbits.github.io/st-tool/',
       bgremover:  'https://plugbits.github.io/background-remover/',
-      stp:        'https://plugbits.github.io/stp-viewer/',
+      stp:        'https://stp-viewer.plugbits.app/',
     };
 
     const TOPBAR_KEYS = {


### PR DESCRIPTION
factory-tools ハブ内の stp-viewer へのリンクを新URL（`https://stp-viewer.plugbits.app/`）に張り替えました。

## Changes

`docs/factory-tools/index.html` の2箇所を更新:

1. ツールカードの起動ボタン `<a href>`
2. `TOOL_URLS` 定数のベースURL

いずれも `https://plugbits.github.io/stp-viewer/` → `https://stp-viewer.plugbits.app/` に変更。他のツールのリンクは変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTJqT4jDg1xn13tGECVhYL)_