### PR TITLE
Unify blog article headings and cross-link bg-remover LP to its post

### DIFF
--- a/content/blog/background-remover.html
+++ b/content/blog/background-remover.html
@@ -1,9 +1,9 @@
 <nav class="kb-article-toc" aria-label="目次">
   <h2>目次</h2>
   <ol class="kb-article-ordered">
-    <li><a href="#motive">検査成績書の写真、背景除去が少し気になっていました</a></li>
-    <li><a href="#first-surprise">ブラウザだけでAIが動くことに驚きました</a></li>
-    <li><a href="#challenge">作ってはみたものの、仕上がりが甘いことがありました</a></li>
+    <li><a href="#motive">検査成績書の写真、背景除去が少し気になっていた</a></li>
+    <li><a href="#first-surprise">ブラウザだけでAIが動くことに驚いた</a></li>
+    <li><a href="#challenge">作ってはみたものの、仕上がりが甘い</a></li>
     <li><a href="#decision">なぜ「ポリゴンで囲む」方式にしたか</a></li>
     <li><a href="#result">手軽に、きれいに、安全に</a></li>
     <li><a href="#faq">よくある質問</a></li>
@@ -11,7 +11,7 @@
 </nav>
 
 <section id="motive" class="kb-article-section">
-  <h2>検査成績書の写真、背景除去が少し気になっていました</h2>
+  <h2>検査成績書の写真、背景除去が少し気になっていた</h2>
   <div class="kb-section-card">
     <p class="kb-article-paragraph">海外の拠点(タイ)から届く検査成績書に、実物の写真が載っていることがあります。背景を消して製品だけを見せる形になっていたのですが、その背景除去の仕上がりが、正直あまりきれいではありませんでした。輪郭がガタついていたり、製品の一部まで消えてしまっていたり。</p>
     <p class="kb-article-paragraph">大きな問題というほどではないのですが、資料として見るたびに「ここ、もう少しきれいにならないかな」と気になっていました。</p>
@@ -19,7 +19,7 @@
 </section>
 
 <section id="first-surprise" class="kb-article-section">
-  <h2>ブラウザだけでAIが動くことに驚きました</h2>
+  <h2>ブラウザだけでAIが動くことに驚いた</h2>
   <div class="kb-section-card">
     <p class="kb-article-paragraph">それで、試しに「画像の背景をAIで自動的に消せないか」と調べてみました。そうしたら、ブラウザの中だけで、しかも無料でAIによる背景除去が動くということを知り、単純に驚きました。ソフトのインストールも、会員登録も必要ありません。</p>
     <p class="kb-article-paragraph">自分はコードを書けないのですが、最近はAIに相談しながら形にできる場面が増えてきていたので、これも試しに作ってみることにしました。</p>
@@ -27,7 +27,7 @@
 </section>
 
 <section id="challenge" class="kb-article-section">
-  <h2>作ってはみたものの、仕上がりが甘いことがありました</h2>
+  <h2>作ってはみたものの、仕上がりが甘い</h2>
   <div class="kb-section-card">
     <p class="kb-article-paragraph">AIと一緒に進めて、ブラウザ上で画像をアップロードすると自動で背景が消える、というところまでは形になりました。ただ、実際に色々な写真で試してみると、自動除去だけでは仕上がりが甘いことがありました。細かい部分が消えきらなかったり、逆に製品の一部まで一緒に消えてしまったり。</p>
     <p class="kb-article-callout"><strong>正直なところ：</strong>自動処理の精度がなぜそこで落ちるのか、技術的な理由は自分ではよく分かっていません。それでも「このままだと惜しい」というのは、見た目で十分わかりました。</p>
@@ -56,19 +56,19 @@
   <h2>よくある質問</h2>
   <div class="kb-faq">
     <div class="kb-faq-item">
-      <h3>無料で使えますか？</h3>
+      <h3>無料で使える？</h3>
       <p>はい、無料でご利用いただけます。</p>
     </div>
     <div class="kb-faq-item">
-      <h3>会員登録は必要ですか？</h3>
+      <h3>会員登録は必要？</h3>
       <p>不要です。ブラウザでアクセスするだけでお使いいただけます。</p>
     </div>
     <div class="kb-faq-item">
-      <h3>画像はサーバーに送信されますか？</h3>
+      <h3>画像はサーバーに送信される？</h3>
       <p>送信されません。処理はブラウザの中だけで完結します。</p>
     </div>
     <div class="kb-faq-item">
-      <h3>どんな画像形式に対応していますか？</h3>
+      <h3>どんな画像形式に対応している？</h3>
       <p>JPEG・PNG・WebPなど主要な形式に対応しています。</p>
     </div>
   </div>

--- a/content/blog/step-file-open.html
+++ b/content/blog/step-file-open.html
@@ -1,9 +1,9 @@
 <nav class="kb-article-toc" aria-label="目次">
   <h2>目次</h2>
   <ol class="kb-article-ordered">
-    <li><a href="#recently">最近、STPファイルで受け取ること、増えていませんか</a></li>
-    <li><a href="#cad-not-everyone">でも、3D CADは誰もが持っているわけではありません</a></li>
-    <li><a href="#why-stp">2D図面ではわかりにくい形状も、STPなら一目でわかります</a></li>
+    <li><a href="#recently">最近、STPファイルで受け取ることが増えている</a></li>
+    <li><a href="#cad-not-everyone">でも、3D CADは誰もが持っているわけではない</a></li>
+    <li><a href="#why-stp">2D図面ではわかりにくい形状も、STPなら一目でわかる</a></li>
     <li><a href="#existing-tools">既存の無料ビューアの、惜しいところ</a></li>
     <li><a href="#solution">登録もインストールも不要。ブラウザだけで開く方法</a></li>
     <li><a href="#how-to">実際の開き方</a></li>
@@ -13,7 +13,7 @@
 </nav>
 
 <section id="recently" class="kb-article-section">
-  <h2>最近、STPファイルで受け取ること、増えていませんか</h2>
+  <h2>最近、STPファイルで受け取ることが増えている</h2>
   <div class="kb-section-card">
     <p class="kb-article-paragraph">取引先や協力会社から、形状データとして STP（STEP）ファイルを受け取る機会が増えてきたと感じている方は多いのではないでしょうか。以前は図面（PDFやDXFなど）でのやり取りが中心だった場面でも、3D CADデータでのやり取りがだんだん当たり前になりつつあります。</p>
     <p class="kb-article-paragraph">メールに添付された「.stp」「.step」というファイルを前に、「これ、どうやって開くんだろう」と手が止まった経験がある方も、きっと少なくないはずです。</p>
@@ -21,7 +21,7 @@
 </section>
 
 <section id="cad-not-everyone" class="kb-article-section">
-  <h2>でも、3D CADは誰もが持っているわけではありません</h2>
+  <h2>でも、3D CADは誰もが持っているわけではない</h2>
   <div class="kb-section-card">
     <p class="kb-article-paragraph">STPファイルを受け取ったものの、いざ開こうとすると「専用ソフトが入っていない」「そもそも何を使えばいいのかわからない」という状況は、決して珍しいことではありません。3D CADは高機能な分、導入にも操作の習得にもそれなりの時間がかかるソフトです。そのため、社内で日常的に3D CADを使いこなせる人は、どうしても限られてしまいます。</p>
     <p class="kb-article-paragraph">営業や購買、事務を担当されている方の手元に3D CADが入っていないのは、むしろ自然なことです。また、技術部門の方であっても、外出先や出張先では普段使っているCAD端末が手元にない、という場面もあるかと思います。</p>
@@ -29,7 +29,7 @@
 </section>
 
 <section id="why-stp" class="kb-article-section">
-  <h2>2D図面ではわかりにくい形状も、STPなら一目でわかります</h2>
+  <h2>2D図面ではわかりにくい形状も、STPなら一目でわかる</h2>
   <div class="kb-section-card">
     <p class="kb-article-paragraph">とはいえ、2D図面だけでは形状の把握が難しい場面もあります。複数の投影図や断面図を見比べながら、頭の中で立体を組み立てるのは、慣れていないとなかなか骨が折れる作業です。特に、曲面を含む部品や、組み立てた状態での干渉・収まりを確認したい場合には、2D図面だけで判断するのは簡単ではありません。</p>
     <p class="kb-article-paragraph">そんな時、STPファイルを開いて3Dの状態でぐるっと回してみると、形状の理解が驚くほど早くなります。「言葉で説明するより、見てもらった方が早い」——これが、STPファイルを開いてみたくなる、一番の理由ではないでしょうか。</p>
@@ -96,19 +96,19 @@
   <h2>よくある質問</h2>
   <div class="kb-faq">
     <div class="kb-faq-item">
-      <h3>無料で使えますか？</h3>
+      <h3>無料で使える？</h3>
       <p>はい、無料でご利用いただけます。</p>
     </div>
     <div class="kb-faq-item">
-      <h3>会員登録は必要ですか？</h3>
+      <h3>会員登録は必要？</h3>
       <p>不要です。ブラウザでアクセスするだけでお使いいただけます。</p>
     </div>
     <div class="kb-faq-item">
-      <h3>スマートフォンでも使えますか？</h3>
+      <h3>スマートフォンでも使える？</h3>
       <p>表示すること自体は可能ですが、画面が狭く細部が見づらいため、タブレット以上の画面サイズでのご利用をおすすめします。</p>
     </div>
     <div class="kb-faq-item">
-      <h3>STEPファイルとSTPファイルは違うものですか？</h3>
+      <h3>STEPファイルとSTPファイルは違うもの？</h3>
       <p>拡張子が異なるだけで、同じファイル形式です（.step / .stp）。どちらもこのツールで開けます。</p>
     </div>
   </div>

--- a/docs/factory-tools/index.html
+++ b/docs/factory-tools/index.html
@@ -658,6 +658,7 @@
             <a href="https://plugbits.github.io/background-remover/" class="launch-btn launch-teal tool-link" data-tool="bgremover" target="_blank" rel="noopener">
               <span data-i18n="openTool"></span> <span>→</span>
             </a>
+            <p style="margin-top:10px;font-size:13px;"><a href="/blog/background-remover/" style="color:#0d9488;">背景除去のコツをブログで解説しています →</a></p>
           </div>
 
           <div class="feature-grid">


### PR DESCRIPTION
## Summary
- Cross-links the Background Remover tool's landing page section (`docs/factory-tools/index.html`) to `/blog/background-remover/`, mirroring the existing STP viewer link.
- Unifies h2/h3 headings in both blog articles to plain form instead of ですます, for a terser, more consistent style (e.g. "仕上がりが甘いことがありました" → "仕上がりが甘い", "無料で使えますか？" → "無料で使える？"). Body paragraphs are unchanged.

## Test plan
- [x] `npm run build` runs cleanly
- [x] Verified the new link and updated headings render correctly in `dist/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WJ4bcoWogktN3mKV83cANi)_