### PR TITLE
ブログのレイアウト改善：入れ子枠の解消・可読性調整・モバイルはみ出し修正・記事メタ1行化

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -261,6 +261,10 @@ try {
       mainEntityOfPage: ogUrl,
     });
 
+    const metaLine = (post.updated_at && post.updated_at !== post.published_at)
+      ? `${formatDateJa(post.published_at)}公開（${formatDateJa(post.updated_at)}更新）・ ${post.read_time}`
+      : `${formatDateJa(post.published_at)}公開 ・ ${post.read_time}`;
+
     const map = {
       '%%TITLE%%':                 esc(post.title),
       '%%H1%%':                    esc(post.h1 || post.title),
@@ -272,6 +276,7 @@ try {
       '%%READ_TIME%%':             esc(post.read_time),
       '%%PUBLISHED_AT_DISPLAY%%':  esc(formatDateJa(post.published_at)),
       '%%UPDATED_AT_DISPLAY%%':    esc(formatDateJa(post.updated_at || post.published_at)),
+      '%%META_LINE%%':             esc(metaLine),
       '%%CTA_INTRO%%':             esc(post.cta_intro),
       '%%TOOL_URL%%':              post.tool_url,
       '%%TOOL_NAME%%':             esc(post.tool_name),

--- a/style.css
+++ b/style.css
@@ -627,7 +627,7 @@
 @media (max-width:720px) {
   .kb-topbar-nav a:not(:last-child) { display:none; }
   .kb-hero-actions { flex-direction:column; }
-  .kb-cta-primary, .kb-cta-secondary { width:100%; }
+  .kb-cta-primary, .kb-cta-secondary { width:100%; box-sizing:border-box; }
   .kb-launcher-card { flex-direction:column; padding:20px; gap:16px; }
   .kb-launcher-card-visual { display:none; }
 }
@@ -1576,7 +1576,7 @@
 @media (max-width: 720px) {
   .kb-ext-featured { flex-direction: column-reverse; padding: 24px 20px; gap: 20px; text-align: left; }
   .kb-ext-featured-visual img { width: 88px; height: 88px; }
-  .kb-ext-cta-row .kb-cta-primary, .kb-ext-cta-row .kb-cta-secondary { width: 100%; }
+  .kb-ext-cta-row .kb-cta-primary, .kb-ext-cta-row .kb-cta-secondary { width: 100%; box-sizing: border-box; }
 }
 
 /* ---- Card hover: image zoom ---- */
@@ -1609,7 +1609,7 @@
 @media (max-width: 600px) {
   .kb-crosssell-inner { padding: 22px 20px; }
   .kb-crosssell-actions { width: 100%; flex-direction: column; }
-  .kb-crosssell-actions .kb-cta-primary, .kb-crosssell-actions .kb-cta-secondary { width: 100%; }
+  .kb-crosssell-actions .kb-cta-primary, .kb-crosssell-actions .kb-cta-secondary { width: 100%; box-sizing: border-box; }
 }
 
 /* ---- Developer note ---- */

--- a/style.css
+++ b/style.css
@@ -1058,7 +1058,7 @@
     align-items: flex-start;
     padding: 20px 20px;
   }
-  .kb-manual-cta .kb-btn-primary { width: 100%; justify-content: center; }
+  .kb-manual-cta .kb-btn-primary { width: 100%; justify-content: center; box-sizing: border-box; }
 }
 
 /* ===================================================================

--- a/templates/blog-index.html
+++ b/templates/blog-index.html
@@ -13,6 +13,13 @@
     .kb-blog-card h3{font-size:17px;line-height:1.4;font-weight:700;margin:0 0 8px;color:var(--kb-text)}
     .kb-blog-card p{color:var(--kb-sub);font-size:14px;line-height:1.6;margin:0 0 16px}
     .kb-blog-card-foot{margin-top:auto;display:flex;align-items:center;justify-content:space-between;font-size:13px;color:var(--kb-muted)}
+
+    /* ===== ファーストビュー調整（このページ限定・2026-07） ===== */
+    .kb-hero .kb-container{padding:36px 0 24px}
+    .kb-index-main .kb-section{padding:16px 0 48px}
+    /* カード高さを揃える */
+    #kb-blog-grid{align-items:stretch}
+    .kb-blog-card{height:100%}
   </style>
 </head>
 <body class="kb-root">

--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -24,14 +24,14 @@
     }
 
     /* ===== 記事レイアウト調整（このテンプレート限定・2026-07） ===== */
-    /* 本文の可読性：コンテンツ幅720px・17px・行間1.9・段落下1.6em */
-    .kb-article-body{max-width:768px;margin:0 auto;padding:0 24px}
+    /* 本文の可読性：コンテンツ幅780px・17px・行間1.9・段落下1.6em */
+    .kb-article-body{max-width:828px;margin:0 auto;padding:0 24px}
     .kb-article-paragraph{font-size:17px;line-height:1.9;margin:0 0 1.6em}
     .kb-article-section{margin-top:52px}
     .kb-article-section h2{font-size:27px;line-height:1.5;margin:0 0 .8em}
     .kb-article-subheading{font-size:20px;margin:2em 0 .6em}
     /* 導入CTAも本文幅に揃える */
-    .kb-article-intro-cta{margin:0 auto 8px;max-width:768px;width:calc(100% - 48px)}
+    .kb-article-intro-cta{margin:0 auto 8px;max-width:828px;width:calc(100% - 48px)}
     /* 中間層（セクションごとの枠）を廃止：見出しと本文を背景に直置き */
     .kb-section-card{background:none;border:none;box-shadow:none;border-radius:0;padding:0;margin-top:0}
     .kb-section-card--stack{display:block}
@@ -41,6 +41,12 @@
     /* チェックリスト：箱を外す（✔は残す） */
     .kb-article-check li{background:none;border:none;box-shadow:none;border-radius:0;padding:2px 0 2px 28px}
     .kb-article-check li::before{left:0;top:2px}
+    /* モバイル：導入CTAボタンのはみ出し防止 */
+    @media (max-width:720px){
+      .kb-article-intro-cta .kb-cta-primary{white-space:normal;flex-shrink:1}
+    }
+    /* 記事メタ：1行表示 */
+    .kb-article-meta-line{margin:16px 0 0;font-size:13.5px;color:var(--kb-sub)}
   </style>
   <script type="application/ld+json">%%JSONLD%%</script>
 </head>
@@ -74,20 +80,7 @@
       <header class="kb-article-header">
         <p class="kb-article-label">%%HERO_LABEL%%</p>
         <h1>%%H1%%</h1>
-        <div class="kb-article-meta">
-          <div class="kb-meta-chip">
-            <strong>公開日</strong>
-            <span>%%PUBLISHED_AT_DISPLAY%%</span>
-          </div>
-          <div class="kb-meta-chip">
-            <strong>更新日</strong>
-            <span>%%UPDATED_AT_DISPLAY%%</span>
-          </div>
-          <div class="kb-meta-chip">
-            <strong>読了目安</strong>
-            <span>%%READ_TIME%%</span>
-          </div>
-        </div>
+        <p class="kb-article-meta-line">%%META_LINE%%</p>
       </header>
 
       <div class="kb-article-intro-cta">

--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -22,6 +22,25 @@
     @media (max-width:720px){
       .kb-article-intro-cta{margin:0 24px 8px;padding:16px 18px}
     }
+
+    /* ===== 記事レイアウト調整（このテンプレート限定・2026-07） ===== */
+    /* 本文の可読性：コンテンツ幅720px・17px・行間1.9・段落下1.6em */
+    .kb-article-body{max-width:768px;margin:0 auto;padding:0 24px}
+    .kb-article-paragraph{font-size:17px;line-height:1.9;margin:0 0 1.6em}
+    .kb-article-section{margin-top:52px}
+    .kb-article-section h2{font-size:27px;line-height:1.5;margin:0 0 .8em}
+    .kb-article-subheading{font-size:20px;margin:2em 0 .6em}
+    /* 導入CTAも本文幅に揃える */
+    .kb-article-intro-cta{margin:0 auto 8px;max-width:768px;width:calc(100% - 48px)}
+    /* 中間層（セクションごとの枠）を廃止：見出しと本文を背景に直置き */
+    .kb-section-card{background:none;border:none;box-shadow:none;border-radius:0;padding:0;margin-top:0}
+    .kb-section-card--stack{display:block}
+    /* 「行き詰まるところ」等の箇条書き：白箱 → 左ボーダー4px */
+    .kb-article-list li{background:none;border:none;box-shadow:none;border-radius:0;border-left:4px solid var(--kb-primary);padding:2px 0 2px 16px}
+    .kb-article-list li::before{content:none}
+    /* チェックリスト：箱を外す（✔は残す） */
+    .kb-article-check li{background:none;border:none;box-shadow:none;border-radius:0;padding:2px 0 2px 28px}
+    .kb-article-check li::before{left:0;top:2px}
   </style>
   <script type="application/ld+json">%%JSONLD%%</script>
 </head>


### PR DESCRIPTION
## Summary
- `templates/blog-post.html`: 記事本文のセクション中間枠（kb-section-card）を廃止し見出し・本文を背景に直置き。本文コンテンツ幅780px・17px・行間1.9・段落下1.6em。h2=27px/h3=20pxで階層差を明確化。箇条書きを白箱→左ボーダー4pxに変更。記事メタ（公開日・更新日・読了目安）を1行テキスト表示に変更。モバイルで導入CTAボタンのはみ出しを防止
- `templates/blog-index.html`: ヒーロー余白を詰めてノートPC（800px高）でも記事カードがファーストビューに収まるよう調整。カード高さのstretchを明示
- `style.css`: モバイルの `width:100%` CTAボタン4箇所に `box-sizing:border-box` を追加し、横スクロール（記事402px・製品407px→いずれも375px）を解消。※box-sizingリセットのセレクタ типо（`.kb-root*`）自体は影響範囲が大きいため未修正
- `scripts/build.js`: 記事メタ1行表示用の `%%META_LINE%%` を追加（更新日は公開日と異なる場合のみ表示）

記事本文テキスト・配色・フォントファミリー・ロゴ・ヘッダーは未変更。目次・FAQ・末尾CTA・注意書き・手順カードの枠は維持。

## Test plan
- [x] `node scripts/build.js` でビルド成功
- [x] Playwrightで before/after スクリーンショット比較（デスクトップ1280x800・モバイル375x812）
- [x] scrollWidth 実測：/blog/kintone-bulk-edit/ 402→375、/products/listkit.html 407→375、/blog/ 375維持
- [x] 他記事（step-file-open）の手順カード・注意書きの崩れなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVyJUZHroH97oJkLRH4ZCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVyJUZHroH97oJkLRH4ZCQ)_