### PR TITLE
ブログ一覧のスマホ表示でカードが重なる不具合を修正

### DIFF
--- a/templates/blog-index.html
+++ b/templates/blog-index.html
@@ -19,7 +19,7 @@
     .kb-index-main .kb-section{padding:16px 0 48px}
     /* カード高さを揃える */
     #kb-blog-grid{align-items:stretch}
-    .kb-blog-card{height:100%}
+    .kb-blog-card{height:100%;box-sizing:border-box}
   </style>
 </head>
 <body class="kb-root">


### PR DESCRIPTION
## Summary
- `templates/blog-index.html`: `.kb-blog-card{height:100%}` に `box-sizing:border-box` を追加

## 原因
記事一覧グリッドが1カラムになるスマホ幅で、各カードが次のカードと約22px重なって表示される不具合をユーザー報告により発見。

サイト共通のbox-sizingリセット（`.kb-root*` というセレクタ記法のため実際には子孫要素に効いていない）の影響で、`.kb-blog-card`はcontent-boxのまま計算されていた。`height:100%`はcontent部分だけを100%にするため、実際の描画高さは「グリッドの行トラック高さ + padding(40px) + border(2px) = +42px」に膨らみ、gapの20pxを上回って次の行と重なっていた。

同根の不具合は過去にモバイルCTAボタンのはみ出しでも発生しており、同じ「該当ルールにbox-sizing:border-boxを局所追加する」方法で対処済み（style.css内の複数箇所）。今回も同じパターンで対処。

## Test plan
- [x] `node scripts/build.js` でビルド成功
- [x] Playwrightで375/390/430px幅の実測を確認：修正前は隣接カードが22px重複、修正後はgap通り20px間隔に
- [x] デスクトップ幅(1280px)で4カラムグリッドの表示に回帰がないことを確認
- [x] ユーザー提供のスクリーンショットと同じ再現条件（5記事・1カラム表示）で修正を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVyJUZHroH97oJkLRH4ZCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVyJUZHroH97oJkLRH4ZCQ)_