### PR TITLE
sitemap.xmlの{{BASE_URL}}未置換バグを修正

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -509,7 +509,7 @@ try {
   urls.push('/blog/');
   for (const post of visiblePosts) urls.push(`/blog/${post.slug}/`);
   const xml = base.replace('</urlset>',
-    urls.map(u => `<url><loc>{{BASE_URL}}${u}</loc></url>`).join('') + '</urlset>'
+    urls.map(u => `<url><loc>${SITE_ORIGIN}${u}</loc></url>`).join('') + '</urlset>'
   );
   fs.writeFileSync(path.join(DIST, 'sitemap.xml'), xml);
 


### PR DESCRIPTION
## Summary
- `scripts/build.js`: sitemap生成箇所で `{{BASE_URL}}` プレースホルダーを実際に置換する処理がなく、本番の `sitemap.xml` に無効なURL（`{{BASE_URL}}/index.html` 等）がそのまま出力され続けていた
- 既存の `SITE_ORIGIN` 定数（`https://plugbits.app`）を使うよう修正し、正しい絶対URLを出力するようにした

デプロイワークフロー（`.github/workflows/build.yml`）にも置換ステップは無く、`node scripts/build.js` の出力をそのままGitHub Pagesにアップロードする構成のため、ビルド側の修正のみで解決する。

## Test plan
- [x] `node scripts/build.js` でビルド成功
- [x] `dist/sitemap.xml` の全19件のURLが `https://plugbits.app/...` の絶対URLで正しく出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVyJUZHroH97oJkLRH4ZCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVyJUZHroH97oJkLRH4ZCQ)_