### PR TITLE
LP: Brevo送信をurlencodedに修正(リスト未登録の不具合)

### DIFF
--- a/docs/drawing/app.js
+++ b/docs/drawing/app.js
@@ -338,11 +338,15 @@ const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)
 
     const formData = new FormData(form);
     formData.set('locale', 'ja');
+    // sibformsはmultipart/form-dataを受け付けないため、ホスト版フォームと同じ
+    // application/x-www-form-urlencoded に変換して送る
+    const body = new URLSearchParams();
+    formData.forEach((value, key) => { body.append(key, String(value)); });
 
     fetch(BREVO_FORM_ACTION, {
       method: 'POST',
       mode: 'no-cors',
-      body: formData,
+      body: body,
     }).then(() => {
       // sibforms responds without CORS headers, so the response here is an
       // opaque object regardless of outcome. resolve() is treated as success;


### PR DESCRIPTION
## 概要

LPからのフォーム送信がBrevoのリストに登録されない不具合の修正です。

## 原因と対応

- sibformsエンドポイントは `multipart/form-data` を解釈しないため、`FormData` を直接fetchに渡すとパラメータが読まれず登録されない(ホスト版フォームからは登録できることで切り分け)
- ホスト版フォームと同じ `application/x-www-form-urlencoded` に変換して送信するよう修正
- Playwrightで送信リクエストを捕捉し、Content-Typeとボディ(EMAIL / LASTNAME / email_address_check / locale)がホスト版と同一形式であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn)_