### PR TITLE
LP: ハニーポットへの自動入力でBrevo登録が破棄される不具合を修正

### DIFF
--- a/docs/drawing/app.js
+++ b/docs/drawing/app.js
@@ -338,6 +338,10 @@ const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)
 
     const formData = new FormData(form);
     formData.set('locale', 'ja');
+    // ハニーポットはブラウザの自動入力(特にSafari)が値を入れてしまうことがあり、
+    // 値が入っているとBrevoは成功を返しつつ登録を黙って破棄する。人間の送信では
+    // 常に空が正なので、送信直前に必ず空へ戻す
+    formData.set('email_address_check', '');
     // sibformsはmultipart/form-dataを受け付けないため、ホスト版フォームと同じ
     // application/x-www-form-urlencoded に変換して送る
     const body = new URLSearchParams();

--- a/docs/drawing/index.html
+++ b/docs/drawing/index.html
@@ -303,7 +303,7 @@
 
             <div class="dw-honeypot" aria-hidden="true">
               <label for="field-hp">この項目は入力しないでください</label>
-              <input type="text" id="field-hp" name="email_address_check" tabindex="-1" autocomplete="off">
+              <input type="text" id="field-hp" name="email_address_check" tabindex="-1" autocomplete="off" readonly>
             </div>
 
             <button type="submit" class="dw-cta-button dw-form-submit">先行案内を受け取る</button>


### PR DESCRIPTION
## 概要

「登録しましたと表示されるのにdrawing-waitlistリストに入らない」不具合の根本修正です。

## 原因

Safariの自動入力が、不可視のボット対策フィールド `email_address_check`(ハニーポット)にメールアドレスを補完していました。ハニーポットに値が入った送信を、Brevoは成功(200)を返しつつ黙って破棄するため、成功表示なのに登録されない状態になっていました(実際の送信ログで確認)。

## 内容

- 送信直前に `email_address_check` を必ず空へ戻す(人間の送信では常に空が正。直接POSTするボットには影響しないためスパム対策は維持)
- ハニーポット入力欄に `readonly` を付与し自動入力自体も抑止
- ハニーポットへ値を注入した状態でも送信ボディが空になることをブラウザ検証で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn)_