### PR TITLE
LP: Twitterカードmeta追加(Xで画像が表示されない件)

### DIFF
--- a/docs/drawing/index.html
+++ b/docs/drawing/index.html
@@ -17,6 +17,9 @@
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="形で、過去の図面を探す — 類似図面検索 for kintone">
+  <meta name="twitter:description" content="kintoneに貯まった図面PDFを、形の似ている順に探せるプラグインを開発しています。先行案内の登録を受け付けています。">
+  <meta name="twitter:image" content="https://plugbits.app/drawing/assets/og.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## 概要

Xに `/drawing/` のURLを貼ってもカード画像が表示されない件の対処です。

## 内容

- `twitter:image` / `twitter:title` / `twitter:description` metaを追加(Xは `og:image` のみではカード画像を表示しないことがあるため明示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn)_