### PR TITLE
robots.txt: Sitemap URLのプレースホルダーを実URLに修正

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
-Sitemap: https://YOUR_USERNAME.github.io/YOUR_REPO/sitemap.xml
+
+Sitemap: https://plugbits.app/sitemap.xml


### PR DESCRIPTION
## 概要

`robots.txt` のSitemap行がテンプレートのプレースホルダー(`https://YOUR_USERNAME.github.io/YOUR_REPO/sitemap.xml`)のままだったため、実URL `https://plugbits.app/sitemap.xml` に修正します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxX8xYjyDpuSjw5mUWNMgn)_